### PR TITLE
feat(cli): add JSON and Markdown export flags for models command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 import { promptCommand, PromptOptions } from "./commands/prompt";
 import { chatCommand, ChatOptions } from "./commands/chat";
-import { listModelsCommand } from "./commands/models";
+import { listModelsCommand, ModelsOptions } from "./commands/models";
 import { doctorCommand } from "./commands/doctor";
 import { skillsCommand } from "./commands/skills";
 
@@ -23,6 +23,7 @@ Options:
   --capability=<cap>    Required capability (e.g. text, reasoning, code, vision, tool_calling)
   --provider=<id>       Force preferred provider (e.g. groq, google, sambanova, openrouter)
   --model=<id>          Force preferred model identifier
+  --format=<format>     Output format for models command: text, json, markdown
   --help, -h            Show this help manual
   --version, -v         Display CLI version
 
@@ -31,6 +32,8 @@ Examples:
   free-ai prompt "Write a quicksort in TypeScript" --capability=code
   free-ai chat --capability=reasoning
   free-ai models
+  free-ai models --format=json
+  free-ai models --format markdown
   free-ai doctor
   free-ai skills install --target=antigravity
 `);
@@ -50,7 +53,18 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
   }
 
   if (command === "models") {
-    listModelsCommand();
+    const modelsOpts: ModelsOptions = {};
+    const rest = argv.slice(1);
+    for (let i = 0; i < rest.length; i++) {
+      const arg = rest[i];
+      if (arg.startsWith("--format=")) {
+        modelsOpts.format = arg.replace("--format=", "");
+      } else if (arg === "--format" && rest[i + 1]) {
+        modelsOpts.format = rest[i + 1];
+        i++;
+      }
+    }
+    listModelsCommand(modelsOpts);
     return;
   }
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,8 +1,46 @@
 import { Registry } from "@free-ai-gateway/core";
 
-export function listModelsCommand(): void {
+export interface ModelsOptions {
+  format?: string;
+}
+
+export function listModelsCommand(options: ModelsOptions = {}): void {
   const registry = new Registry();
   const adapters = registry.getAllAdapters();
+
+  if (options.format === "json") {
+    const list: Array<{
+      provider: string;
+      model: string;
+      capabilities: string[];
+    }> = [];
+
+    for (const adapter of adapters) {
+      for (const model of adapter.config.models) {
+        list.push({
+          provider: adapter.config.id,
+          model: model.id,
+          capabilities: model.capabilities,
+        });
+      }
+    }
+
+    console.log(JSON.stringify(list, null, 2));
+    return;
+  }
+
+  if (options.format === "markdown") {
+    console.log("| Provider ID | Model ID | Capabilities |");
+    console.log("| :--- | :--- | :--- |");
+    for (const adapter of adapters) {
+      for (const model of adapter.config.models) {
+        console.log(
+          `| ${adapter.config.id} | ${model.id} | ${model.capabilities.join(", ")} |`
+        );
+      }
+    }
+    return;
+  }
 
   console.log("\n📦 Free-AI Gateway - Discovered Models & Capabilities\n");
   console.log("--------------------------------------------------------------------------------");

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -21,7 +21,7 @@ describe("Free-AI Gateway CLI", () => {
     }
   });
 
-  it("should list discovered models", async () => {
+  it("should list discovered models in default text format", async () => {
     let output = "";
     const originalLog = console.log;
     console.log = (...args: any[]) => {
@@ -32,6 +32,60 @@ describe("Free-AI Gateway CLI", () => {
       await runCli(["models"]);
       assert.ok(output.includes("Discovered Models & Capabilities"));
       assert.ok(output.includes("Provider ID"));
+      assert.ok(output.includes("groq"));
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("should output models in valid JSON format with --format=json", async () => {
+    let output = "";
+    const originalLog = console.log;
+    console.log = (...args: any[]) => {
+      output += args.join(" ") + "\n";
+    };
+
+    try {
+      await runCli(["models", "--format=json"]);
+      const parsed = JSON.parse(output.trim());
+      assert.ok(Array.isArray(parsed));
+      assert.ok(parsed.length > 0);
+      assert.ok(parsed[0].provider);
+      assert.ok(parsed[0].model);
+      assert.ok(Array.isArray(parsed[0].capabilities));
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("should output models in valid JSON format with --format json", async () => {
+    let output = "";
+    const originalLog = console.log;
+    console.log = (...args: any[]) => {
+      output += args.join(" ") + "\n";
+    };
+
+    try {
+      await runCli(["models", "--format", "json"]);
+      const parsed = JSON.parse(output.trim());
+      assert.ok(Array.isArray(parsed));
+      assert.ok(parsed.length > 0);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("should output models in Markdown table format with --format=markdown", async () => {
+    let output = "";
+    const originalLog = console.log;
+    console.log = (...args: any[]) => {
+      output += args.join(" ") + "\n";
+    };
+
+    try {
+      await runCli(["models", "--format=markdown"]);
+      assert.ok(output.includes("| Provider ID | Model ID | Capabilities |"));
+      assert.ok(output.includes("| :--- | :--- | :--- |"));
       assert.ok(output.includes("groq"));
     } finally {
       console.log = originalLog;


### PR DESCRIPTION
## 💡 Description
Implements structured export flags (`--format=json` and `--format=markdown`) for the `free-ai models` CLI command as specified in #5.

## 🎯 Changes
- Added `ModelsOptions` to `packages/cli/src/commands/models.ts` supporting `format: "json" | "markdown"`.
- Output machine-readable JSON array of discovered models, providers, and capability arrays when `--format json` is supplied.
- Output formatted GitHub Markdown table of discovered models when `--format markdown` is supplied.
- Preserved default formatted text table output when no `--format` flag is provided.
- Added comprehensive unit tests in `packages/cli/tests/cli.test.ts` covering both `--format=json` and `--format=markdown`.

Closes #5