### PR TITLE
feat(gateway): implement Prometheus metrics endpoint (/metrics)

### DIFF
--- a/apps/gateway/src/api/routes/metrics.ts
+++ b/apps/gateway/src/api/routes/metrics.ts
@@ -1,0 +1,79 @@
+import { FastifyInstance } from "fastify";
+import { RouteDependencies } from "./route-factory";
+
+/**
+ * Prometheus metrics exporter endpoint (/metrics).
+ * Exports operational metrics for Prometheus scrapers and Grafana dashboards.
+ */
+export default async function metricsRoute(fastify: FastifyInstance, opts: RouteDependencies) {
+  fastify.get("/metrics", async (request, reply) => {
+    const lines: string[] = [];
+
+    // Helper to format labels
+    const formatLabels = (labels: Record<string, string | number>) => {
+      const entries = Object.entries(labels)
+        .filter(([_, v]) => v !== undefined && v !== null)
+        .map(([k, v]) => `${k}="${String(v).replace(/"/g, '\\"')}"`);
+      return entries.length > 0 ? `{${entries.join(",")}}` : "";
+    };
+
+    // 1. Metric: free_ai_gateway_active_providers_count
+    lines.push("# HELP free_ai_gateway_active_providers_count Total number of active/loaded AI provider adapters.");
+    lines.push("# TYPE free_ai_gateway_active_providers_count gauge");
+    lines.push(`free_ai_gateway_active_providers_count ${opts.registry.adapters.length}`);
+    lines.push("");
+
+    // 2. Metric: free_ai_gateway_circuit_breaker_state
+    lines.push("# HELP free_ai_gateway_circuit_breaker_state Circuit breaker state (1 = open/tripped, 0 = closed/healthy).");
+    lines.push("# TYPE free_ai_gateway_circuit_breaker_state gauge");
+    for (const adapter of opts.registry.adapters) {
+      const pid = adapter.config.id;
+      const status = opts.circuitBreaker.getStatus(pid);
+      const isBreakerOpen = status.isOpen ? 1 : 0;
+      lines.push(`free_ai_gateway_circuit_breaker_state${formatLabels({ provider: pid, state: status.isOpen ? "open" : "closed" })} ${isBreakerOpen}`);
+    }
+    lines.push("");
+
+    // 3. Metric: free_ai_gateway_requests_total
+    lines.push("# HELP free_ai_gateway_requests_total Total number of AI capability requests processed by provider and status.");
+    lines.push("# TYPE free_ai_gateway_requests_total counter");
+    const allMetrics = opts.metricsTracker.getAllMetrics();
+    for (const [pid, metrics] of Object.entries(allMetrics)) {
+      if (metrics.successCount > 0) {
+        lines.push(`free_ai_gateway_requests_total${formatLabels({ provider: pid, status: "success" })} ${metrics.successCount}`);
+      }
+      if (metrics.failureCount > 0) {
+        lines.push(`free_ai_gateway_requests_total${formatLabels({ provider: pid, status: "failure" })} ${metrics.failureCount}`);
+      }
+    }
+    lines.push("");
+
+    // 4. Metric: free_ai_gateway_request_duration_seconds
+    lines.push("# HELP free_ai_gateway_request_duration_seconds Average request duration in seconds for provider.");
+    lines.push("# TYPE free_ai_gateway_request_duration_seconds gauge");
+    for (const [pid, metrics] of Object.entries(allMetrics)) {
+      const durationSeconds = metrics.avgLatencyMs ? (metrics.avgLatencyMs / 1000).toFixed(4) : "0";
+      lines.push(`free_ai_gateway_request_duration_seconds${formatLabels({ provider: pid })} ${durationSeconds}`);
+    }
+    lines.push("");
+
+    // 5. Metric: free_ai_gateway_provider_health_state
+    lines.push("# HELP free_ai_gateway_provider_health_state Health indicator of provider (1 = healthy, 0 = unhealthy).");
+    lines.push("# TYPE free_ai_gateway_provider_health_state gauge");
+    for (const adapter of opts.registry.adapters) {
+      const pid = adapter.config.id;
+      const m = opts.metricsTracker.getMetrics(pid);
+      lines.push(`free_ai_gateway_provider_health_state${formatLabels({ provider: pid })} ${m.isHealthy ? 1 : 0}`);
+    }
+    lines.push("");
+
+    // 6. Metric: free_ai_gateway_uptime_seconds
+    lines.push("# HELP free_ai_gateway_uptime_seconds Process uptime in seconds.");
+    lines.push("# TYPE free_ai_gateway_uptime_seconds gauge");
+    lines.push(`free_ai_gateway_uptime_seconds ${Math.floor(process.uptime())}`);
+    lines.push("");
+
+    reply.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    return reply.send(lines.join("\n"));
+  });
+}

--- a/apps/gateway/tests/server.test.ts
+++ b/apps/gateway/tests/server.test.ts
@@ -18,6 +18,28 @@ describe("Gateway HTTP Server Integration", () => {
     assert.ok(response.headers["x-response-time"]);
   });
 
+  it("GET /metrics should return Prometheus formatted metrics", async () => {
+    const { server, metricsTracker } = createServer();
+    metricsTracker.recordSuccess("groq", 120);
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/metrics",
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.ok(response.headers["content-type"]?.includes("text/plain"));
+    const body = response.body;
+
+    assert.ok(body.includes("free_ai_gateway_active_providers_count 19"));
+    assert.ok(body.includes("free_ai_gateway_circuit_breaker_state"));
+    assert.ok(body.includes("free_ai_gateway_requests_total"));
+    assert.ok(body.includes('free_ai_gateway_requests_total{provider="groq",status="success"} 1'));
+    assert.ok(body.includes("free_ai_gateway_request_duration_seconds"));
+    assert.ok(body.includes("free_ai_gateway_provider_health_state"));
+    assert.ok(body.includes("free_ai_gateway_uptime_seconds"));
+  });
+
   it("GET /v1/models should return OpenAI-compatible list of models", async () => {
     const { server } = createServer();
     const response = await server.inject({


### PR DESCRIPTION
## 💡 Feature Implementation (Closes #6)

This PR implements the Prometheus-compatible operational metrics endpoint (`/metrics`) on the Fastify Gateway application (`apps/gateway`).

### 🎯 Key Enhancements
1. **Prometheus Metrics Exporter Route (`/metrics`)**:
   - `free_ai_gateway_active_providers_count`: Gauge of active/loaded provider adapters.
   - `free_ai_gateway_circuit_breaker_state{provider, state}`: Gauge indicating 1 (open/tripped) or 0 (closed/healthy) per provider.
   - `free_ai_gateway_requests_total{provider, status}`: Counter tracking successful vs failed requests per provider.
   - `free_ai_gateway_request_duration_seconds{provider}`: Gauge exposing latency in seconds per provider.
   - `free_ai_gateway_provider_health_state{provider}`: Gauge of health state per provider.
   - `free_ai_gateway_uptime_seconds`: Gauge of process uptime.
2. **Proper Content-Type Header**:
   - Sets standard Prometheus scrape format `text/plain; version=0.0.4; charset=utf-8`.
3. **Automated Autoloading**:
   - Integrates with the existing `RouteLoader` discovery mechanism.
4. **Integration Test Suite**:
   - Added test case in `apps/gateway/tests/server.test.ts` to verify the `/metrics` output format and labels.

### 🧪 Verification
- `npm run typecheck` across all monorepo workspaces: **PASS**
- `npm run build` across all packages: **PASS**
- `npm test` across all monorepo test suites + E2E integration: **PASS** (39/39 tests passing)
