### PR TITLE
docs: add Next.js 14+ App Router & Vercel AI SDK integration tutorial

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -18,6 +18,7 @@ Welcome to the definitive learning guide for **Free-AI Gateway**! Whether you ar
    - [Tutorial 2: Adding a Custom Provider Adapter](#tutorial-2-adding-a-custom-provider-adapter)
    - [Tutorial 3: Connecting Your IDE (Cursor, Claude, Antigravity)](#tutorial-3-connecting-your-ide-cursor-claude-antigravity)
    - [Tutorial 4: Terminal AI & REPL with the CLI](#tutorial-4-terminal-ai--repl-with-the-cli)
+   - [Tutorial 5: Next.js 14+ App Router & Vercel AI SDK Integration](#tutorial-5-nextjs-14-app-router--vercel-ai-sdk-integration)
 9. [Advanced Patterns & FAQ](#-advanced-patterns--faq)
 
 ---
@@ -394,6 +395,72 @@ free-ai doctor
 # Search available models for structured output
 free-ai models --capability structured_output
 ```
+
+---
+
+### Tutorial 5: Next.js 14+ App Router & Vercel AI SDK Integration
+
+Free-AI Gateway provides full OpenAI compatibility, making it seamless to integrate into Next.js 14+ App Router applications with streaming and the Vercel AI SDK.
+
+#### 1. Setup Next.js Route Handler (`app/api/chat/route.ts`)
+```typescript
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import OpenAI from 'openai';
+
+// Point standard OpenAI SDK to local Free-AI Gateway
+const openai = new OpenAI({
+  apiKey: process.env.FREE_AI_API_KEY || 'free-ai-gateway-local',
+  baseURL: process.env.FREE_AI_GATEWAY_URL || 'http://localhost:3000/v1',
+});
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const { messages, model = 'groq/llama-3.3-70b-versatile' } = await req.json();
+
+  const response = await openai.chat.completions.create({
+    model,
+    stream: true,
+    messages,
+  });
+
+  const stream = OpenAIStream(response);
+  return new StreamingTextResponse(stream);
+}
+```
+
+#### 2. Streaming UI Component (`app/page.tsx`)
+```tsx
+'use client';
+
+import { useChat } from 'ai/react';
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat();
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map(m => (
+        <div key={m.id} className="whitespace-pre-wrap">
+          {m.role === 'user' ? 'User: ' : 'AI: '}
+          {m.content}
+        </div>
+      ))}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input}
+          placeholder="Say something..."
+          onChange={handleInputChange}
+        />
+      </form>
+    </div>
+  );
+}
+```
+
+Check out the complete runnable template in [`examples/nextjs-chat/`](examples/nextjs-chat/).
 
 ---
 

--- a/examples/nextjs-chat/README.md
+++ b/examples/nextjs-chat/README.md
@@ -1,0 +1,193 @@
+# Next.js 14+ (App Router) Integration Example with Free-AI Gateway
+
+This example demonstrates how to integrate **Free-AI Gateway** with a **Next.js 14+ (App Router)** application.
+
+It shows:
+1. Connecting Next.js Route Handlers (`app/api/chat/route.ts`) to Free-AI Gateway's OpenAI-compatible endpoint (`http://localhost:3000/v1/chat/completions`).
+2. Streaming responses via Server-Sent Events (SSE).
+3. Using the **Vercel AI SDK** (`ai` package) with standard OpenAI client configuration.
+4. Native standard `fetch` streaming implementation without external dependencies.
+
+---
+
+## 🛠️ Prerequisites
+
+1. Ensure your Free-AI Gateway is running locally on `http://localhost:3000`:
+   ```bash
+   # In the free-ai-gateway root
+   npm run build
+   npm start
+   ```
+
+2. Make sure you have at least one free provider key configured in `.env` (e.g. `GROQ_API_KEY`, `GOOGLE_AI_STUDIO_API_KEY`, or `OPENROUTER_API_KEY`).
+
+---
+
+## 📁 Project Structure
+
+```
+examples/nextjs-chat/
+├── app/
+│   ├── api/
+│   │   ├── chat/
+│   │   │   └── route.ts          # Vercel AI SDK streaming route handler
+│   │   └── chat-native/
+│   │       └── route.ts          # Native fetch SSE streaming route handler
+│   ├── layout.tsx                # Root layout
+│   └── page.tsx                  # Interactive chat component
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+---
+
+## 🚀 Code Walkthrough
+
+### 1. Route Handler with Vercel AI SDK (`app/api/chat/route.ts`)
+
+```typescript
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import OpenAI from 'openai';
+
+// Point the OpenAI client to Free-AI Gateway local endpoint
+const openai = new OpenAI({
+  apiKey: process.env.FREE_AI_API_KEY || 'free-ai-gateway-local',
+  baseURL: process.env.FREE_AI_GATEWAY_URL || 'http://localhost:3000/v1',
+});
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const { messages, model = 'groq/llama-3.3-70b-versatile' } = await req.json();
+
+  const response = await openai.chat.completions.create({
+    model,
+    stream: true,
+    messages,
+  });
+
+  const stream = OpenAIStream(response);
+  return new StreamingTextResponse(stream);
+}
+```
+
+### 2. Route Handler with Native Fetch & SSE (`app/api/chat-native/route.ts`)
+
+If you prefer zero external dependencies, you can proxy the SSE stream directly:
+
+```typescript
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const { messages, model = 'groq/llama-3.3-70b-versatile' } = await req.json();
+  const gatewayUrl = process.env.FREE_AI_GATEWAY_URL || 'http://localhost:3000/v1';
+
+  const gatewayResponse = await fetch(`${gatewayUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.FREE_AI_API_KEY || 'local'}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      stream: true,
+    }),
+  });
+
+  if (!gatewayResponse.ok) {
+    const errorText = await gatewayResponse.text();
+    return new Response(errorText, {
+      status: gatewayResponse.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Forward the SSE stream directly to the client
+  return new Response(gatewayResponse.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}
+```
+
+### 3. Frontend Chat Component (`app/page.tsx`)
+
+```tsx
+'use client';
+
+import { useChat } from 'ai/react';
+import { useState } from 'react';
+
+export default function ChatPage() {
+  const [selectedModel, setSelectedModel] = useState('groq/llama-3.3-70b-versatile');
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
+    api: '/api/chat',
+    body: { model: selectedModel },
+  });
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 flex flex-col h-screen">
+      <header className="py-4 border-b flex justify-between items-center">
+        <h1 className="text-xl font-bold">Free-AI Gateway Chat</h1>
+        <select
+          value={selectedModel}
+          onChange={(e) => setSelectedModel(e.target.value)}
+          className="border rounded p-1 text-sm bg-background"
+        >
+          <option value="groq/llama-3.3-70b-versatile">Groq: Llama 3.3 70B</option>
+          <option value="google/gemini-2.0-flash">Google: Gemini 2.0 Flash</option>
+          <option value="openrouter/auto">OpenRouter: Auto Free</option>
+          <option value="sambanova/Meta-Llama-3.1-8B-Instruct">SambaNova: Llama 3.1 8B</option>
+        </select>
+      </header>
+
+      <div className="flex-1 overflow-y-auto py-4 space-y-4">
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            className={`p-3 rounded-lg ${
+              m.role === 'user' ? 'bg-blue-600 text-white ml-auto max-w-[80%]' : 'bg-muted max-w-[80%]'
+            }`}
+          >
+            <p className="text-xs font-semibold uppercase opacity-75 mb-1">{m.role}</p>
+            <p className="whitespace-pre-wrap">{m.content}</p>
+          </div>
+        ))}
+        {isLoading && <div className="text-sm text-muted-foreground animate-pulse">Thinking...</div>}
+      </div>
+
+      <form onSubmit={handleSubmit} className="py-4 border-t flex gap-2">
+        <input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask anything (routed via Free-AI Gateway)..."
+          className="flex-1 border rounded p-2 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          className="bg-primary text-primary-foreground px-4 py-2 rounded text-sm disabled:opacity-50"
+        >
+          Send
+        </button>
+      </form>
+    </main>
+  );
+}
+```
+
+---
+
+## ⚙️ Environment Variables
+
+Create `.env.local` in your Next.js project:
+
+```env
+FREE_AI_GATEWAY_URL=http://localhost:3000/v1
+FREE_AI_API_KEY=free-ai-gateway-local
+```

--- a/examples/nextjs-chat/app/api/chat-native/route.ts
+++ b/examples/nextjs-chat/app/api/chat-native/route.ts
@@ -1,0 +1,36 @@
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const { messages, model = 'groq/llama-3.3-70b-versatile' } = await req.json();
+  const gatewayUrl = process.env.FREE_AI_GATEWAY_URL || 'http://localhost:3000/v1';
+
+  const gatewayResponse = await fetch(`${gatewayUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.FREE_AI_API_KEY || 'local'}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      stream: true,
+    }),
+  });
+
+  if (!gatewayResponse.ok) {
+    const errorText = await gatewayResponse.text();
+    return new Response(errorText, {
+      status: gatewayResponse.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Forward the SSE stream directly to the client
+  return new Response(gatewayResponse.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/examples/nextjs-chat/app/api/chat/route.ts
+++ b/examples/nextjs-chat/app/api/chat/route.ts
@@ -1,0 +1,23 @@
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import OpenAI from 'openai';
+
+// Point the OpenAI client to Free-AI Gateway local endpoint
+const openai = new OpenAI({
+  apiKey: process.env.FREE_AI_API_KEY || 'free-ai-gateway-local',
+  baseURL: process.env.FREE_AI_GATEWAY_URL || 'http://localhost:3000/v1',
+});
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const { messages, model = 'groq/llama-3.3-70b-versatile' } = await req.json();
+
+  const response = await openai.chat.completions.create({
+    model,
+    stream: true,
+    messages,
+  });
+
+  const stream = OpenAIStream(response);
+  return new StreamingTextResponse(stream);
+}

--- a/examples/nextjs-chat/app/layout.tsx
+++ b/examples/nextjs-chat/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Free-AI Gateway Chat Demo',
+  description: 'Next.js App Router integration with Free-AI Gateway',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, fontFamily: 'system-ui, sans-serif' }}>{children}</body>
+    </html>
+  );
+}

--- a/examples/nextjs-chat/app/page.tsx
+++ b/examples/nextjs-chat/app/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useChat } from 'ai/react';
+import { useState } from 'react';
+
+export default function ChatPage() {
+  const [selectedModel, setSelectedModel] = useState('groq/llama-3.3-70b-versatile');
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
+    api: '/api/chat',
+    body: { model: selectedModel },
+  });
+
+  return (
+    <main style={{ maxWidth: 800, margin: '0 auto', padding: 24, display: 'flex', flexDirection: 'column', height: '100vh', boxSizing: 'border-box' }}>
+      <header style={{ paddingBottom: 16, borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1 style={{ fontSize: 20, margin: 0 }}>Free-AI Gateway + Next.js App Router</h1>
+        <select
+          value={selectedModel}
+          onChange={(e) => setSelectedModel(e.target.value)}
+          style={{ padding: '6px 12px', borderRadius: 6, border: '1px solid #ccc' }}
+        >
+          <option value="groq/llama-3.3-70b-versatile">Groq: Llama 3.3 70B</option>
+          <option value="google/gemini-2.0-flash">Google: Gemini 2.0 Flash</option>
+          <option value="openrouter/auto">OpenRouter: Auto Free</option>
+          <option value="sambanova/Meta-Llama-3.1-8B-Instruct">SambaNova: Llama 3.1 8B</option>
+        </select>
+      </header>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px 0', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {messages.length === 0 && (
+          <p style={{ color: '#888', fontStyle: 'italic', textAlign: 'center', marginTop: 40 }}>
+            Type a prompt below to start streaming responses from Free-AI Gateway.
+          </p>
+        )}
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            style={{
+              padding: 12,
+              borderRadius: 8,
+              maxWidth: '80%',
+              alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start',
+              backgroundColor: m.role === 'user' ? '#2563eb' : '#f3f4f6',
+              color: m.role === 'user' ? '#fff' : '#111',
+            }}
+          >
+            <div style={{ fontSize: 10, fontWeight: 'bold', textTransform: 'uppercase', marginBottom: 4, opacity: 0.8 }}>
+              {m.role}
+            </div>
+            <div style={{ whiteSpace: 'pre-wrap' }}>{m.content}</div>
+          </div>
+        ))}
+        {isLoading && <div style={{ color: '#6b7280', fontSize: 14 }}>Thinking...</div>}
+      </div>
+
+      <form onSubmit={handleSubmit} style={{ paddingTop: 16, borderTop: '1px solid #e5e7eb', display: 'flex', gap: 8 }}>
+        <input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask anything (routed via Free-AI Gateway)..."
+          style={{ flex: 1, padding: 10, borderRadius: 6, border: '1px solid #ccc', fontSize: 14 }}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          style={{
+            backgroundColor: '#2563eb',
+            color: '#fff',
+            padding: '10px 20px',
+            borderRadius: 6,
+            border: 'none',
+            cursor: isLoading || !input.trim() ? 'not-allowed' : 'pointer',
+            opacity: isLoading || !input.trim() ? 0.6 : 1,
+            fontWeight: 600,
+          }}
+        >
+          Send
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/examples/nextjs-chat/package.json
+++ b/examples/nextjs-chat/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "nextjs-chat-free-ai-gateway",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "ai": "^3.0.0",
+    "next": "^14.2.0",
+    "openai": "^4.33.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/nextjs-chat/tsconfig.json
+++ b/examples/nextjs-chat/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
Closes #3.

This PR adds a comprehensive step-by-step tutorial and runnable example project for integrating Free-AI Gateway with Next.js 14+ App Router.

### What is included:
1. **Tutorial in `LEARN.md`**:
   - Step-by-step walkthrough of connecting Next.js Route Handlers to `http://localhost:3000/v1/chat/completions`.
   - Streaming SSE responses with Vercel AI SDK (`ai` package).
   - Direct SSE streaming with native `fetch` (zero-dep).
2. **Runnable Example Project in `examples/nextjs-chat/`**:
   - Complete Next.js 14 App Router project setup with `package.json`, `tsconfig.json`, `app/layout.tsx`, and `app/page.tsx` UI chat interface with dynamic model picker.
   - Route handler `app/api/chat/route.ts` using OpenAI SDK + Vercel AI SDK `OpenAIStream`.
   - Route handler `app/api/chat-native/route.ts` forwarding raw SSE stream from gateway.
   - Detailed `README.md` explaining prerequisites, environment configuration, and code mechanics.

### Verification
- Ran `npm test` across all workspaces (cli, core, gateway, mcp, skills, e2e monorepo) - all 36 tests passing cleanly.
- Verified TypeScript definitions and file syntax.