### PR TITLE
docs: add Postman and Bruno API collections for capability endpoints (#7)

### DIFF
--- a/examples/collections/README.md
+++ b/examples/collections/README.md
@@ -1,0 +1,49 @@
+# Free-AI Gateway API Collections (Postman & Bruno)
+
+This directory contains pre-configured, ready-to-import collections for **Postman** and **Bruno** to test all OpenAI-compatible endpoints and specialized AI capability routes provided by Free-AI Gateway.
+
+---
+
+## 🚀 Endpoints Covered
+
+| Category | Endpoint | Method | Description |
+| :--- | :--- | :--- | :--- |
+| **System & Diagnostics** | `/health` | `GET` | System health check, uptime, active adapters & metrics |
+| **Models** | `/v1/models` | `GET` | List available models across all configured providers |
+| **Admin** | `/admin/providers` | `GET` | Circuit breaker status & detailed provider health |
+| **Chat Completions** | `/v1/chat/completions` | `POST` | Standard text completion & chat format |
+| **Chat Completions** | `/v1/chat/completions` (Code) | `POST` | Code generation & reasoning requests |
+| **Chat Completions** | `/v1/chat/completions` (Streaming) | `POST` | Server-Sent Events (SSE) streaming chat |
+| **Embeddings** | `/v1/embeddings` | `POST` | Vector embeddings generation for text & documents |
+| **Audio** | `/v1/audio/transcriptions` | `POST` | Audio transcription (Speech-to-Text) |
+| **Audio** | `/v1/audio/speech` | `POST` | Text-to-Speech audio synthesis |
+| **Reranking** | `/v1/rerank` | `POST` | Document & passage relevance reranking for RAG |
+| **Document Processing** | `/v1/documents/parse` | `POST` | Document ingestion, extraction & parsing |
+| **Web Search** | `/v1/search` | `POST` | Live web search via configured provider |
+| **Moderation** | `/v1/moderate` | `POST` | Content safety & policy moderation |
+| **Vision** | `/v1/vision/analyze` | `POST` | Multi-modal image analysis |
+| **Translation** | `/v1/translate` | `POST` | Multi-language translation |
+
+---
+
+## 📦 Using with Postman
+
+1. Open Postman.
+2. Click **Import** in the upper-left navigation bar.
+3. Select `examples/collections/postman/Free-AI-Gateway.postman_collection.json`.
+4. (Optional) Import `examples/collections/postman/Free-AI-Gateway.postman_environment.json`.
+5. Set `baseUrl` to `http://localhost:3000` (or your gateway's running host/port).
+6. Start testing any endpoint immediately!
+
+---
+
+## 🐶 Using with Bruno
+
+[Bruno](https://www.usebruno.com/) is an open-source, Git-friendly API client.
+
+1. Open Bruno.
+2. Click **Open Collection**.
+3. Select the folder `examples/collections/bruno`.
+4. Choose the `Local` environment.
+5. Ensure the gateway server is running (`npm start` or `npm run dev` in `apps/gateway`).
+6. Run the collection requests.

--- a/examples/collections/bruno/Audio/Synthesize Speech.bru
+++ b/examples/collections/bruno/Audio/Synthesize Speech.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Synthesize Speech
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/audio/speech
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "input": "Welcome to Free AI Gateway.",
+    "voice": "alloy"
+  }
+}

--- a/examples/collections/bruno/Audio/Transcribe Audio.bru
+++ b/examples/collections/bruno/Audio/Transcribe Audio.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Transcribe Audio
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/audio/transcriptions
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "audio_url": "https://example.com/sample.mp3",
+    "language": "en"
+  }
+}

--- a/examples/collections/bruno/Chat Completions/Code Completion.bru
+++ b/examples/collections/bruno/Chat Completions/Code Completion.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Code Completion
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/chat/completions
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "model": "auto:code",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a TypeScript function to debounce an async API call."
+      }
+    ],
+    "temperature": 0.2
+  }
+}

--- a/examples/collections/bruno/Chat Completions/Provider Pinning.bru
+++ b/examples/collections/bruno/Chat Completions/Provider Pinning.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Provider Pinning
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/chat/completions
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "model": "groq:llama-3.3-70b-versatile",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello Groq!"
+      }
+    ]
+  }
+}

--- a/examples/collections/bruno/Chat Completions/Standard Chat.bru
+++ b/examples/collections/bruno/Chat Completions/Standard Chat.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Standard Chat Completion
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/chat/completions
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "model": "auto:text",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful AI assistant."
+      },
+      {
+        "role": "user",
+        "content": "Explain what an AI API gateway is in 2 sentences."
+      }
+    ],
+    "temperature": 0.7,
+    "max_tokens": 256
+  }
+}

--- a/examples/collections/bruno/Chat Completions/Stream Chat.bru
+++ b/examples/collections/bruno/Chat Completions/Stream Chat.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Stream Chat Completion
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/v1/chat/completions
+  body: json
+  auth: bearer
+}
+
+headers {
+  Accept: text/event-stream
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "model": "auto:text",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Count from 1 to 5 slowly."
+      }
+    ],
+    "stream": true
+  }
+}

--- a/examples/collections/bruno/Embeddings/Generate Embeddings.bru
+++ b/examples/collections/bruno/Embeddings/Generate Embeddings.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Generate Embeddings
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/embeddings
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "model": "auto:embedding",
+    "input": [
+      "High-performance AI gateway for microservices",
+      "Zero cost resilience and fallback routing"
+    ]
+  }
+}

--- a/examples/collections/bruno/Models/List Models.bru
+++ b/examples/collections/bruno/Models/List Models.bru
@@ -1,0 +1,15 @@
+meta {
+  name: List Models
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/v1/models
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}

--- a/examples/collections/bruno/Rerank & Search/Rerank Documents.bru
+++ b/examples/collections/bruno/Rerank & Search/Rerank Documents.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Rerank Documents
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/rerank
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "query": "What is an AI gateway?",
+    "documents": [
+      "An AI gateway routes and manages requests across multiple LLM APIs.",
+      "A database stores structured rows of data.",
+      "Microservices architecture partitions applications into separate services."
+    ],
+    "top_n": 2
+  }
+}

--- a/examples/collections/bruno/Rerank & Search/Web Search.bru
+++ b/examples/collections/bruno/Rerank & Search/Web Search.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Live Web Search
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/search
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "query": "Latest breakthroughs in open source AI router architectures",
+    "max_results": 5
+  }
+}

--- a/examples/collections/bruno/Specialized Capabilities/Document Parse.bru
+++ b/examples/collections/bruno/Specialized Capabilities/Document Parse.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Document Parse
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/documents/parse
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "document_url": "https://example.com/sample.pdf",
+    "extract_images": false
+  }
+}

--- a/examples/collections/bruno/Specialized Capabilities/Image Generation.bru
+++ b/examples/collections/bruno/Specialized Capabilities/Image Generation.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Image Generation
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/v1/images/generations
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "prompt": "A minimalist cyberpunk workstation in neon light, digital art",
+    "n": 1,
+    "size": "1024x1024"
+  }
+}

--- a/examples/collections/bruno/Specialized Capabilities/Moderation.bru
+++ b/examples/collections/bruno/Specialized Capabilities/Moderation.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Content Moderation
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/moderate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "input": "This is a clean, helpful, and safe test prompt for content moderation."
+  }
+}

--- a/examples/collections/bruno/Specialized Capabilities/Translation.bru
+++ b/examples/collections/bruno/Specialized Capabilities/Translation.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Translation
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/translate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "text": "Welcome to Free AI Gateway. Connecting open source intelligence.",
+    "source_lang": "en",
+    "target_lang": "es"
+  }
+}

--- a/examples/collections/bruno/Specialized Capabilities/Vision Analysis.bru
+++ b/examples/collections/bruno/Specialized Capabilities/Vision Analysis.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Vision Analysis
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/v1/vision/analyze
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{apiKey}}
+}
+
+body:json {
+  {
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+    "prompt": "Describe the landscape and colors in this scene."
+  }
+}

--- a/examples/collections/bruno/System & Health/Admin Providers.bru
+++ b/examples/collections/bruno/System & Health/Admin Providers.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Admin Providers
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/admin/providers
+  body: none
+  auth: none
+}

--- a/examples/collections/bruno/System & Health/Health Status.bru
+++ b/examples/collections/bruno/System & Health/Health Status.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Health Status
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}

--- a/examples/collections/bruno/bruno.json
+++ b/examples/collections/bruno/bruno.json
@@ -1,0 +1,7 @@
+version = "1"
+name = "Free-AI Gateway"
+type = "collection"
+ignore = [
+  "node_modules",
+  ".git"
+]

--- a/examples/collections/bruno/environments/Local.bru
+++ b/examples/collections/bruno/environments/Local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:3000
+  apiKey: sk-free-ai-gateway
+}

--- a/examples/collections/postman/Free-AI-Gateway.postman_collection.json
+++ b/examples/collections/postman/Free-AI-Gateway.postman_collection.json
@@ -1,0 +1,501 @@
+{
+  "info": {
+    "_postman_id": "7b8f9e01-c872-4b2a-9f4a-89a101f3e792",
+    "name": "Free-AI Gateway",
+    "description": "Comprehensive API collection for testing all OpenAI-compatible and capability endpoints supported by Free-AI Gateway.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "string"
+    },
+    {
+      "key": "apiKey",
+      "value": "sk-free-ai-gateway",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "System & Health",
+      "item": [
+        {
+          "name": "Health Status",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["health"]
+            },
+            "description": "Returns uptime, provider counts, and health metrics."
+          },
+          "response": []
+        },
+        {
+          "name": "Admin Providers & Metrics",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/providers",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "providers"]
+            },
+            "description": "Lists all registered provider adapters, circuit breaker statuses, and quota limits."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Models",
+      "item": [
+        {
+          "name": "List Available Models",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/models",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "models"]
+            },
+            "description": "Lists OpenAI-compatible models available across active providers."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Chat Completions",
+      "item": [
+        {
+          "name": "Standard Chat Completion",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"auto:text\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a helpful and concise AI assistant.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Explain the Model Context Protocol (MCP) in 2 sentences.\"\n    }\n  ],\n  \"temperature\": 0.7,\n  \"max_tokens\": 256\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "chat", "completions"]
+            },
+            "description": "Standard conversational chat completion routed through optimal active provider."
+          },
+          "response": []
+        },
+        {
+          "name": "Code Generation & Reasoning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"auto:code\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Write a TypeScript function to debounce an async API call.\"\n    }\n  ],\n  \"temperature\": 0.2\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "chat", "completions"]
+            },
+            "description": "Targeting code capability models (e.g. Qwen Coder, DeepSeek Coder)."
+          },
+          "response": []
+        },
+        {
+          "name": "Streaming Chat Completion (SSE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "text/event-stream"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"auto:text\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Count from 1 to 5 slowly.\"\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "chat", "completions"]
+            },
+            "description": "Server-Sent Events streaming chat completion response."
+          },
+          "response": []
+        },
+        {
+          "name": "Provider Pinning (Groq)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"groq:llama-3.3-70b-versatile\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello Groq!\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "chat", "completions"]
+            },
+            "description": "Direct routing to a specific provider adapter using provider:model format."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Embeddings",
+      "item": [
+        {
+          "name": "Generate Vector Embeddings",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"input\": [\n    \"High-performance AI gateway for microservices\",\n    \"Zero cost resilience and fallback routing\"\n  ],\n  \"model\": \"auto:embedding\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/embeddings",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "embeddings"]
+            },
+            "description": "Generates dense vector embeddings for RAG search indexing."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Audio",
+      "item": [
+        {
+          "name": "Audio Transcription (Speech-to-Text)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"audio_url\": \"https://example.com/sample.mp3\",\n  \"language\": \"en\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/audio/transcriptions",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "audio", "transcriptions"]
+            },
+            "description": "Transcribes audio files into text using automatic speech recognition."
+          },
+          "response": []
+        },
+        {
+          "name": "Text to Speech Synthesis",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"input\": \"Welcome to Free AI Gateway.\",\n  \"voice\": \"alloy\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/audio/speech",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "audio", "speech"]
+            },
+            "description": "Synthesizes spoken audio from text."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Reranking & Search",
+      "item": [
+        {
+          "name": "Rerank Documents",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"What is an AI gateway?\",\n  \"documents\": [\n    \"An AI gateway routes and manages requests across multiple LLM APIs.\",\n    \"A database stores structured rows of data.\",\n    \"Microservices architecture partitions applications into separate services.\"\n  ],\n  \"top_n\": 2\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "rerank"]
+            },
+            "description": "Scores and ranks document relevance against a search query."
+          },
+          "response": []
+        },
+        {
+          "name": "Live Web Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"Latest breakthroughs in open source AI router architectures\",\n  \"max_results\": 5\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/search",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "search"]
+            },
+            "description": "Performs web search via providers like Tavily, Exa, or Google."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Specialized Capabilities",
+      "item": [
+        {
+          "name": "Document Processing & Parsing",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"document_url\": \"https://example.com/whitepaper.pdf\",\n  \"extract_images\": false\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/documents/parse",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "documents", "parse"]
+            },
+            "description": "Extracts structured elements and text from documents."
+          },
+          "response": []
+        },
+        {
+          "name": "Content Moderation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"input\": \"This is a clean, helpful, and safe test prompt for content moderation.\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/moderate",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "moderate"]
+            },
+            "description": "Evaluates text against safety policies."
+          },
+          "response": []
+        },
+        {
+          "name": "Vision Analysis",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"image_url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n  \"prompt\": \"Describe the landscape and colors in this scene.\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/vision/analyze",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "vision", "analyze"]
+            },
+            "description": "Analyzes image content with vision-capable multimodal LLMs."
+          },
+          "response": []
+        },
+        {
+          "name": "Translation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"text\": \"Welcome to Free AI Gateway. Connecting open source intelligence.\",\n  \"source_lang\": \"en\",\n  \"target_lang\": \"es\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/translate",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "translate"]
+            },
+            "description": "Translates text across supported language pairs."
+          },
+          "response": []
+        },
+        {
+          "name": "Image Generation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"prompt\": \"A minimalist cyberpunk workstation in neon light, digital art\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/images/generations",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "images", "generations"]
+            },
+            "description": "Generates synthetic images from descriptive prompts."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/examples/collections/postman/Free-AI-Gateway.postman_environment.json
+++ b/examples/collections/postman/Free-AI-Gateway.postman_environment.json
@@ -1,0 +1,21 @@
+{
+  "id": "e9b110a2-a8c4-4b51-968a-c603e5c9423b",
+  "name": "Free-AI Gateway Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "apiKey",
+      "value": "sk-free-ai-gateway",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-08-18T10:15:00.000Z",
+  "_postman_exported_using": "Postman/11.0.0"
+}


### PR DESCRIPTION
## Description
Closes #7.

Provides ready-to-import API test collections for both **Postman** (v2.1 collection format + environment) and **[Bruno](https://www.usebruno.com/)** under `examples/collections/`.

### Endpoints Covered:
- `GET /health` (System diagnostics, uptime, provider count, metrics)
- `GET /admin/providers` (Provider adapters, limits, breaker statuses)
- `GET /v1/models` (OpenAI-compatible models catalog)
- `POST /v1/chat/completions` (Standard text, Code reasoning, SSE Streaming, and Provider Pinning)
- `POST /v1/embeddings` (Vector embeddings generation)
- `POST /v1/audio/transcriptions` (Speech-to-Text)
- `POST /v1/audio/speech` (Text-to-Speech)
- `POST /v1/rerank` (Document scoring and reranking for RAG)
- `POST /v1/search` (Live web search via Tavily/Exa/Google)
- `POST /v1/documents/parse` (Document extraction & processing)
- `POST /v1/moderate` (Content moderation)
- `POST /v1/vision/analyze` (Multimodal vision analysis)
- `POST /v1/translate` (Translation)
- `POST /v1/images/generations` (Image generation)

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New provider adapter
- [ ] ⚡ Performance / Resilience improvement
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring / Code hygiene

## Checklist
- [x] My code follows the project's code style and standards.
- [x] I have tested all requests against a running local gateway instance.
- [x] I have added instructions in `examples/collections/README.md`.
