### PR TITLE
feat(core): add configurable retry policy

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,8 @@ export {
 export type {
   LimitScope,
   RateLimitSpec,
+  RetryJitter,
+  RetryPolicy,
   ProviderModel,
   ProviderConfig,
   UnifiedRequest,

--- a/packages/core/src/resilience/retry-policy.ts
+++ b/packages/core/src/resilience/retry-policy.ts
@@ -1,0 +1,45 @@
+import { RetryPolicy } from "../types/contracts";
+
+export interface RetryRuntime {
+  random: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export const defaultRetryRuntime: RetryRuntime = {
+  random: () => Math.random(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export function normalizeRetryCount(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizedDelay(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(0, value);
+}
+
+export function initialRetryDelay(policy: RetryPolicy): number {
+  const maxDelayMs = normalizedDelay(policy.maxDelayMs, 5000);
+  return Math.min(normalizedDelay(policy.baseDelayMs, 1000), maxDelayMs);
+}
+
+export function retryDelay(
+  attempt: number,
+  previousDelayMs: number,
+  policy: RetryPolicy,
+  random: () => number
+): number {
+  const maxDelayMs = normalizedDelay(policy.maxDelayMs, 5000);
+  const baseDelayMs = Math.min(normalizedDelay(policy.baseDelayMs, 1000), maxDelayMs);
+  const sample = Math.min(1, Math.max(0, random()));
+
+  if ((policy.jitter ?? "full") === "decorrelated") {
+    const upper = Math.max(baseDelayMs, previousDelayMs * 3);
+    return Math.min(baseDelayMs + sample * (upper - baseDelayMs), maxDelayMs);
+  }
+
+  const cap = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+  return sample * cap;
+}

--- a/packages/core/src/router/capability-router.ts
+++ b/packages/core/src/router/capability-router.ts
@@ -1,7 +1,13 @@
-import { UnifiedRequest, UnifiedResponse } from "../types/contracts";
+import { RetryPolicy, UnifiedRequest, UnifiedResponse } from "../types/contracts";
 import { Registry } from "../providers/registry";
 import { QuotaTracker } from "../resilience/quota-tracker";
 import { CircuitBreaker } from "../resilience/circuit-breaker";
+import {
+  defaultRetryRuntime,
+  initialRetryDelay,
+  retryDelay,
+  RetryRuntime,
+} from "../resilience/retry-policy";
 import { MetricsTracker } from "../observability/metrics-tracker";
 import { EventBus } from "../observability/event-bus";
 import { NoProviderAvailableError } from "../errors/errors";
@@ -23,6 +29,38 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+function mergeRetryPolicy(base: RetryPolicy, override?: RetryPolicy): RetryPolicy {
+  if (!override) return base;
+  return {
+    ...base,
+    ...override,
+    maxProviderAttemptsByCapability: {
+      ...(base.maxProviderAttemptsByCapability ?? {}),
+      ...(override.maxProviderAttemptsByCapability ?? {}),
+    },
+  };
+}
+
+function normalizeAttemptLimit(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  return Math.max(1, Math.floor(value));
+}
+
+function maxProviderAttempts(request: UnifiedRequest, policy: RetryPolicy): number {
+  const limits: number[] = [];
+  const globalLimit = normalizeAttemptLimit(policy.maxProviderAttempts);
+  if (globalLimit !== undefined) limits.push(globalLimit);
+
+  for (const capability of request.capabilities) {
+    const capabilityLimit = normalizeAttemptLimit(
+      policy.maxProviderAttemptsByCapability?.[capability]
+    );
+    if (capabilityLimit !== undefined) limits.push(capabilityLimit);
+  }
+
+  return limits.length > 0 ? Math.min(...limits) : Number.POSITIVE_INFINITY;
+}
+
 /**
  * Enterprise Capability Router
  * Coordinates candidate selection, health filtering, circuit breaking,
@@ -35,13 +73,18 @@ export class CapabilityRouter {
     public readonly breaker: CircuitBreaker,
     public readonly metricsTracker?: MetricsTracker,
     public readonly eventBus?: EventBus,
-    public readonly strategy: IRoutingStrategy = new AdaptiveHealthStrategy()
+    public readonly strategy: IRoutingStrategy = new AdaptiveHealthStrategy(),
+    public readonly retryPolicy: RetryPolicy = {},
+    private readonly retryRuntime: RetryRuntime = defaultRetryRuntime
   ) {}
 
   /**
    * Routes a unified capability request to the optimal healthy provider with automatic failover.
    */
-  public async route(request: UnifiedRequest): Promise<UnifiedResponse> {
+  public async route(
+    request: UnifiedRequest,
+    retryPolicyOverride?: RetryPolicy
+  ): Promise<UnifiedResponse> {
     const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
     this.eventBus?.emit("request:start", {
@@ -61,8 +104,16 @@ export class CapabilityRouter {
 
     const attempted: string[] = [];
     const timeoutMs = request.timeoutMs ?? 30_000;
+    const retryPolicy = mergeRetryPolicy(this.retryPolicy, retryPolicyOverride);
+    const attemptLimit = maxProviderAttempts(request, retryPolicy);
+    const hasRetryPolicy = Object.keys(retryPolicy).length > 0;
+    let previousDelayMs = hasRetryPolicy ? initialRetryDelay(retryPolicy) : 0;
+    let retryIndex = 0;
 
-    for (const { adapter, model } of candidates) {
+    for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
+      if (attempted.length >= attemptLimit) break;
+
+      const { adapter, model } = candidates[candidateIndex];
       const key = `${adapter.config.id}:${model.id}`;
 
       // 1. Check proactive quota limits (RPM, RPD, TPM, TPD & cooldown)
@@ -117,7 +168,21 @@ export class CapabilityRouter {
           error: err?.message || String(err),
         });
 
-        if (!retryable) continue;
+        if (!retryable) break;
+
+        const canAttemptAgain =
+          attempted.length < attemptLimit && candidateIndex < candidates.length - 1;
+        if (canAttemptAgain && hasRetryPolicy) {
+          const delayMs = retryDelay(
+            retryIndex,
+            previousDelayMs,
+            retryPolicy,
+            this.retryRuntime.random
+          );
+          retryIndex += 1;
+          previousDelayMs = delayMs;
+          await this.retryRuntime.sleep(delayMs);
+        }
       }
     }
 
@@ -133,8 +198,17 @@ export async function route(
   registry: Registry,
   quota: QuotaTracker,
   breaker: CircuitBreaker,
-  metricsTracker?: MetricsTracker
+  metricsTracker?: MetricsTracker,
+  retryPolicy?: RetryPolicy
 ): Promise<UnifiedResponse> {
-  const router = new CapabilityRouter(registry, quota, breaker, metricsTracker);
+  const router = new CapabilityRouter(
+    registry,
+    quota,
+    breaker,
+    metricsTracker,
+    undefined,
+    undefined,
+    retryPolicy
+  );
   return router.route(request);
 }

--- a/packages/core/src/transport/http-client.ts
+++ b/packages/core/src/transport/http-client.ts
@@ -1,11 +1,29 @@
 import { ProviderError } from "../errors/errors";
+import { RetryPolicy } from "../types/contracts";
+import {
+  defaultRetryRuntime,
+  initialRetryDelay,
+  normalizeRetryCount,
+  retryDelay,
+  RetryRuntime,
+} from "../resilience/retry-policy";
 
 export interface HttpRequestOptions {
   headers?: Record<string, string>;
   body?: any;
   timeoutMs?: number;
   retries?: number;
+  retryPolicy?: RetryPolicy;
 }
+
+export interface HttpClientRuntime extends RetryRuntime {
+  fetch: typeof fetch;
+}
+
+const defaultRuntime: HttpClientRuntime = {
+  fetch: (...args) => fetch(...args),
+  ...defaultRetryRuntime,
+};
 
 /**
  * Enterprise HTTP Transport client with built-in timeouts, automatic retries,
@@ -14,7 +32,8 @@ export interface HttpRequestOptions {
 export class HttpClient {
   constructor(
     private readonly baseUrl: string,
-    private readonly defaultHeaders: Record<string, string> = {}
+    private readonly defaultHeaders: Record<string, string> = {},
+    private readonly runtime: HttpClientRuntime = defaultRuntime
   ) {}
 
   /**
@@ -27,7 +46,9 @@ export class HttpClient {
   ): Promise<{ data: T; status: number; headers: Headers }> {
     const url = `${this.baseUrl.replace(/\/+$/, "")}/${endpoint.replace(/^\/+/, "")}`;
     const timeoutMs = options.timeoutMs ?? 30_000;
-    const retries = options.retries ?? 1;
+    const retries = options.retryPolicy
+      ? normalizeRetryCount(options.retryPolicy.maxTransportRetries, options.retries ?? 1)
+      : options.retries ?? 1;
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -36,13 +57,14 @@ export class HttpClient {
     };
 
     let lastError: unknown;
+    let previousDelayMs = options.retryPolicy ? initialRetryDelay(options.retryPolicy) : 1000;
 
     for (let attempt = 0; attempt <= retries; attempt++) {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
       try {
-        const response = await fetch(url, {
+        const response = await this.runtime.fetch(url, {
           method: "POST",
           headers,
           body: JSON.stringify(payload),
@@ -65,15 +87,17 @@ export class HttpClient {
         clearTimeout(timeoutId);
         lastError = err;
 
-        // If it's a 4xx error (like 400 or 429), don't retry on the transport level
+        // Preserve current transport semantics: 4xx, including 429, are routed upward.
         if (err instanceof ProviderError && err.status < 500) {
           throw err;
         }
 
         if (attempt < retries) {
-          // Exponential backoff with jitter before retry
-          const backoff = Math.min(1000 * Math.pow(2, attempt) + Math.random() * 200, 5000);
-          await new Promise((r) => setTimeout(r, backoff));
+          const delayMs = options.retryPolicy
+            ? retryDelay(attempt, previousDelayMs, options.retryPolicy, this.runtime.random)
+            : Math.min(1000 * Math.pow(2, attempt) + this.runtime.random() * 200, 5000);
+          previousDelayMs = delayMs;
+          await this.runtime.sleep(delayMs);
         }
       }
     }

--- a/packages/core/src/types/contracts.ts
+++ b/packages/core/src/types/contracts.ts
@@ -9,6 +9,23 @@ export interface RateLimitSpec {
   tpd?: number;
 }
 
+export type RetryJitter = "full" | "decorrelated";
+
+export interface RetryPolicy {
+  /** Number of same-provider HTTP retries after the initial transport attempt. */
+  maxTransportRetries?: number;
+  /** Base delay used by full/decorrelated jitter. Defaults to 1000 ms. */
+  baseDelayMs?: number;
+  /** Maximum delay used by full/decorrelated jitter. Defaults to 5000 ms. */
+  maxDelayMs?: number;
+  /** Jitter algorithm used when a retry/failover delay is applied. Defaults to full jitter. */
+  jitter?: RetryJitter;
+  /** Maximum provider/model attempts for one routed request, including the initial attempt. */
+  maxProviderAttempts?: number;
+  /** Per-capability provider/model attempt caps; the strictest matching cap wins. */
+  maxProviderAttemptsByCapability?: Partial<Record<Capability, number>>;
+}
+
 export interface ProviderModel {
   id: string;
   capabilities: Capability[];

--- a/packages/core/tests/retry-policy.test.ts
+++ b/packages/core/tests/retry-policy.test.ts
@@ -1,0 +1,238 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { HttpClient, HttpClientRuntime } from "../src/transport/http-client";
+import { CapabilityRouter } from "../src/router/capability-router";
+import { Registry } from "../src/providers/registry";
+import { QuotaTracker } from "../src/resilience/quota-tracker";
+import { CircuitBreaker } from "../src/resilience/circuit-breaker";
+import { MemoryConfigurationSource } from "../src/config/config-source";
+import { NoProviderAvailableError, ProviderError } from "../src/errors/errors";
+import { ProviderAdapter, ProviderConfig, RetryPolicy } from "../src/types/contracts";
+
+interface ResponseSpec {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+function makeHttpRuntime(responses: ResponseSpec[], randomValue = 0.5) {
+  const delays: number[] = [];
+  let calls = 0;
+
+  const runtime: HttpClientRuntime = {
+    fetch: async () => {
+      const response = responses[Math.min(calls, responses.length - 1)];
+      calls += 1;
+      return new Response(JSON.stringify(response.body ?? {}), {
+        status: response.status,
+        headers: response.headers,
+      });
+    },
+    random: () => randomValue,
+    sleep: async (ms) => {
+      delays.push(ms);
+    },
+  };
+
+  return {
+    runtime,
+    delays,
+    calls: () => calls,
+  };
+}
+
+function providerConfig(id: string): ProviderConfig {
+  return {
+    id,
+    name: id,
+    base_url: `https://${id}.example.test`,
+    auth: "api_key",
+    limit_scope: "account",
+    openai_compatible: true,
+    confidence: "official",
+    models: [{ id: `${id}-model`, capabilities: ["text"] }],
+  };
+}
+
+function makeAdapter(id: string, retryable: boolean, succeeds = false) {
+  let calls = 0;
+  const config = providerConfig(id);
+
+  const adapter: ProviderAdapter = {
+    config,
+    supports: (capability) => config.models.some((model) => model.capabilities.includes(capability)),
+    invoke: async (_request, model) => {
+      calls += 1;
+      if (!succeeds) throw new Error(`${id} failed`);
+      return {
+        servedBy: { provider: id, model: model.id },
+        data: { ok: true },
+      };
+    },
+    translateError: () => ({ retryable, rateLimited: false }),
+  };
+
+  return {
+    adapter,
+    calls: () => calls,
+  };
+}
+
+function makeRouter(
+  adapters: ProviderAdapter[],
+  retryPolicy: RetryPolicy = {},
+  randomValue = 0.5
+) {
+  const registry = new Registry(new MemoryConfigurationSource({ providers: [] }));
+  registry.adapters = adapters;
+
+  const quota = new QuotaTracker("./state/test-retry-policy-quota.json");
+  quota.reset();
+  const delays: number[] = [];
+
+  const router = new CapabilityRouter(
+    registry,
+    quota,
+    new CircuitBreaker(),
+    undefined,
+    undefined,
+    undefined,
+    retryPolicy,
+    {
+      random: () => randomValue,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    }
+  );
+
+  return { router, delays };
+}
+
+describe("RetryPolicy", () => {
+  it("applies deterministic full jitter to transport retries", async () => {
+    const probe = makeHttpRuntime([
+      { status: 503 },
+      { status: 200, body: { ok: true } },
+    ]);
+    const client = new HttpClient("https://example.test", {}, probe.runtime);
+
+    const response = await client.post("v1", {}, {
+      retryPolicy: {
+        maxTransportRetries: 1,
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        jitter: "full",
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(probe.calls(), 2);
+    assert.deepEqual(probe.delays, [50]);
+  });
+
+  it("applies deterministic decorrelated jitter across retries", async () => {
+    const probe = makeHttpRuntime([
+      { status: 503 },
+      { status: 503 },
+      { status: 200 },
+    ]);
+    const client = new HttpClient("https://example.test", {}, probe.runtime);
+
+    await client.post("v1", {}, {
+      retryPolicy: {
+        maxTransportRetries: 2,
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        jitter: "decorrelated",
+      },
+    });
+
+    assert.equal(probe.calls(), 3);
+    assert.deepEqual(probe.delays, [200, 350]);
+  });
+
+  it("keeps 429 transport-terminal so the router can apply quota semantics", async () => {
+    const probe = makeHttpRuntime([
+      { status: 429, headers: { "retry-after": "2" } },
+      { status: 200 },
+    ]);
+    const client = new HttpClient("https://example.test", {}, probe.runtime);
+
+    await assert.rejects(
+      () =>
+        client.post("v1", {}, {
+          retryPolicy: { maxTransportRetries: 3, jitter: "full" },
+        }),
+      (err) =>
+        err instanceof ProviderError && err.status === 429 && err.retryAfterMs === 2000
+    );
+
+    assert.equal(probe.calls(), 1);
+    assert.deepEqual(probe.delays, []);
+  });
+
+  it("preserves legacy additive jitter when no retry policy is supplied", async () => {
+    const probe = makeHttpRuntime([{ status: 503 }, { status: 200 }]);
+    const client = new HttpClient("https://example.test", {}, probe.runtime);
+
+    await client.post("v1", {}, { retries: 1 });
+
+    assert.deepEqual(probe.delays, [1100]);
+  });
+
+  it("stops provider failover after a non-retryable failure", async () => {
+    const first = makeAdapter("first", false);
+    const backup = makeAdapter("backup", true, true);
+    const { router, delays } = makeRouter([first.adapter, backup.adapter]);
+
+    await assert.rejects(
+      () => router.route({ capabilities: ["text"], payload: {} }),
+      (err) => err instanceof NoProviderAvailableError && err.attempted.length === 1
+    );
+
+    assert.equal(first.calls(), 1);
+    assert.equal(backup.calls(), 0);
+    assert.deepEqual(delays, []);
+  });
+
+  it("bounds failover by capability and applies router jitter", async () => {
+    const first = makeAdapter("first", true);
+    const second = makeAdapter("second", true);
+    const third = makeAdapter("third", true);
+    const { router, delays } = makeRouter(
+      [first.adapter, second.adapter, third.adapter],
+      {
+        maxProviderAttemptsByCapability: { text: 2 },
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        jitter: "full",
+      }
+    );
+
+    await assert.rejects(
+      () => router.route({ capabilities: ["text"], payload: {} }),
+      (err) => err instanceof NoProviderAvailableError && err.attempted.length === 2
+    );
+
+    assert.deepEqual([first.calls(), second.calls(), third.calls()], [1, 1, 0]);
+    assert.deepEqual(delays, [50]);
+  });
+
+  it("allows a per-call policy to override the router default", async () => {
+    const first = makeAdapter("first", true);
+    const backup = makeAdapter("backup", true, true);
+    const { router, delays } = makeRouter(
+      [first.adapter, backup.adapter],
+      { maxProviderAttempts: 1, baseDelayMs: 100, jitter: "full" }
+    );
+
+    const response = await router.route(
+      { capabilities: ["text"], payload: {} },
+      { maxProviderAttempts: 2 }
+    );
+
+    assert.equal(response.servedBy.provider, "backup");
+    assert.deepEqual(delays, [50]);
+  });
+});


### PR DESCRIPTION
## Description

Adds a configurable retry policy for `@free-ai-gateway/core` while keeping transport retries and provider failover as separate, bounded concerns.

This PR:

- introduces a typed `RetryPolicy` with configurable backoff and jitter;
- supports full and decorrelated jitter with injectable RNG/sleep for deterministic tests;
- adds per-capability provider-attempt limits in `CapabilityRouter`;
- makes `retryable: false` stop provider failover instead of continuing to the next candidate;
- preserves existing behavior when no retry policy is supplied;
- keeps HTTP 429 handling at the router/quota boundary rather than silently retrying it at the transport layer;
- adds focused regression coverage for jitter bounds, retry exhaustion, failover limits, non-retryable failures, and backward compatibility.

Closes #18

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New provider adapter
- [x] ⚡ Performance / Resilience improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring / Code hygiene

## Validation

Focused local validation completed:

- strict TypeScript compilation of the changed surface: PASS
- retry-policy behavioral regression suite: 7/7 PASS

Full repository `npm run typecheck` and `npm test` are intentionally left to the pull-request CI matrix before this draft is marked ready for review.

## Checklist
- [x] My code follows the project's code style and standards.
- [ ] I have run `npm run typecheck` and `npm test` and all checks passed.
- [x] I have updated documentation (`README.md`, `.env.example`, `CONTRIBUTING.md`) if applicable.
- [x] If adding a new provider adapter, I verified it with `providers.schema.json` and registered it in `src/core/registry.ts`.